### PR TITLE
Update the version of YugabyteDB JDBC Smart driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.yugabyte</groupId>
 			<artifactId>jdbc-yugabytedb</artifactId>
-			<version>42.3.5-yb-1</version>
+			<version>42.3.5-yb-2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -15,7 +15,7 @@ spring:
         portNumber: 5433
         databaseName: yugabyte
         additionalEndpoints:
-        topologyKeys: "aws.us-west-2"
+        topologyKeys: "aws.us-west-2.*"
 
 
 logging.level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
         serverName: ${node:127.0.0.1}
         portNumber: ${port:5433}
         databaseName: ${dbname:yugabyte}
-        topologyKeys: "aws.us-west-2"
+        topologyKeys: "aws.us-west-2.*"
         #ssl: ${ssl:false}
         #sslmode: ${sslmode:disable}
         #sslrootcert: ${sslrootcert:~/.ssh/ybcloudcert/root.crt}


### PR DESCRIPTION
- Update the version of YugabyteDB JDBC Smart driver and correct the topology-keys.
- This version has a fix for the case when a node specified in the connection string goes down while the workload is running, then the app does not fail. This was a case raised by @ddhodge
- Also, corrected the topology-keys values. It should either be of the form `cloud.region.zone` or `cloud.region.*`. Latter includes all the zones in the region.