### PR TITLE
Simplify Run with docker and docker-compose

### DIFF
--- a/demo.Dockerfile
+++ b/demo.Dockerfile
@@ -1,0 +1,34 @@
+ARG JAVA_VERSION=19
+
+ARG JDK_IMAGE=eclipse-temurin
+ARG JDK_IMAGE_TAG=${JAVA_VERSION}-jdk
+
+ARG JRE_IMAGE=eclipse-temurin
+ARG JRE_IMAGE_TAG=${JAVA_VERSION}-jre
+ARG JAR_FILE=yb-workload-sim.jar
+ARG APP_NAME=workload-simulator
+ARG APP_PORT=8080
+
+FROM ${JDK_IMAGE}:${JDK_IMAGE_TAG} as build
+RUN mkdir -p /opt/workspace
+WORKDIR /opt/workspace
+COPY pom.xml ./mvnw ./
+COPY .mvn/ .mvn/
+RUN ./mvnw -B clean -DskipDockerBuild -DskipTests dependency:resolve-plugins dependency:resolve
+ADD . .
+RUN ./mvnw -B clean package -DskipTests
+
+
+FROM ${JRE_IMAGE}:${JRE_IMAGE_TAG} as main
+ARG JAR_FILE
+LABEL MAINTAINER YugaByte
+ENV container=${APP_NAME}
+
+WORKDIR /opt/yugabyte
+COPY --from=build /opt/workspace/target/${JAR_FILE} /opt/yugabyte/
+USER nobody
+
+EXPOSE ${APP_PORT}
+ENV JAR_FILE=${JAR_FILE}
+ENV JAVA_OPTS=""
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS}  -jar /opt/yugabyte/${JAR_FILE}"]

--- a/docker-compose.demo.yaml
+++ b/docker-compose.demo.yaml
@@ -158,9 +158,7 @@ services:
       retries: 10
 
   app:
-    build:
-      context: .
-      dockerfile: demo.Dockerfile
+    image: ghcr.io/yogendra/yb-workload-simu-app
     container_name: app
     hostname: app
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,173 @@
+#; indent_size=4
+networks:
+  lab:
+    driver: bridge
+services:
+  yb-master-0:
+    image: yugabytedb/yugabyte:2.18.0.1-b4
+    platform: linux/amd64
+    cap_add:
+      - NET_ADMIN
+    container_name: yb-master-0
+    hostname: yb-master-0.zone.region.cloud
+    command: |
+      bash -c "
+        rm -rf /tmp/.yb* ;
+        /home/yugabyte/bin/yb-master --ysql_beta_feature_tablespace_alteration=true --ysql_enable_packed_row=true --ysql_beta_features=true --yb_enable_read_committed_isolation=true --default_memory_limit_to_ram_ratio=0.20 --fs_data_dirs=/home/yugabyte/data --placement_cloud=cloud --placement_region=region --placement_zone=zone --rpc_bind_addresses=yb-master-0.zone.region.cloud:7100 --master_addresses=yb-master-0:7100,yb-master-1:7100,yb-master-2:7100 --replication_factor=3 --rpc_connection_timeout_ms=15000
+
+      "
+    ports:
+      - "7000:7000"
+    networks:
+      - lab
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://yb-master-0"]
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  yb-master-1:
+    image: yugabytedb/yugabyte:2.18.0.1-b4
+    platform: linux/amd64
+    cap_add:
+      - NET_ADMIN
+    container_name: yb-master-1
+    hostname: yb-master-1.zone.region.cloud
+    command: |
+      bash -c "
+        rm -rf /tmp/.yb* ;
+        /home/yugabyte/bin/yb-master --ysql_beta_feature_tablespace_alteration=true --ysql_enable_packed_row=true --ysql_beta_features=true --yb_enable_read_committed_isolation=true --default_memory_limit_to_ram_ratio=0.20 --fs_data_dirs=/home/yugabyte/data --placement_cloud=cloud --placement_region=region --placement_zone=zone --rpc_bind_addresses=yb-master-1.zone.region.cloud:7100 --master_addresses=yb-master-0:7100,yb-master-1:7100,yb-master-2:7100 --replication_factor=3 --rpc_connection_timeout_ms=15000
+
+      "
+    ports:
+      - "7001:7000"
+    networks:
+      - lab
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://yb-master-1"]
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  yb-master-2:
+    image: yugabytedb/yugabyte:2.18.0.1-b4
+    platform: linux/amd64
+    cap_add:
+      - NET_ADMIN
+    container_name: yb-master-2
+    hostname: yb-master-2.zone.region.cloud
+    command: |
+      bash -c "
+        rm -rf /tmp/.yb* ;
+        /home/yugabyte/bin/yb-master --ysql_beta_feature_tablespace_alteration=true --ysql_enable_packed_row=true --ysql_beta_features=true --yb_enable_read_committed_isolation=true --default_memory_limit_to_ram_ratio=0.20 --fs_data_dirs=/home/yugabyte/data --placement_cloud=cloud --placement_region=region --placement_zone=zone --rpc_bind_addresses=yb-master-2.zone.region.cloud:7100 --master_addresses=yb-master-0:7100,yb-master-1:7100,yb-master-2:7100 --replication_factor=3 --rpc_connection_timeout_ms=15000
+
+      "
+    ports:
+      - "7002:7000"
+    networks:
+      - lab
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://yb-master-2"]
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  yb-tserver-0:
+    image: yugabytedb/yugabyte:2.18.0.1-b4
+    platform: linux/amd64
+    cap_add:
+      - NET_ADMIN
+    container_name: yb-tserver-0
+    hostname: yb-tserver-0.zone.region.cloud
+    command: |
+      bash -c "
+        rm -rf /tmp/.yb* ;
+        /home/yugabyte/bin/yb-tserver --ysql_beta_feature_tablespace_alteration=true --ysql_enable_packed_row=true --ysql_beta_features=true --yb_enable_read_committed_isolation=true --default_memory_limit_to_ram_ratio=0.20 --placement_cloud=cloud --placement_region=region --placement_zone=zone --enable_ysql=true --fs_data_dirs=/home/yugabyte/data --rpc_bind_addresses=yb-tserver-0.zone.region.cloud:9100 --tserver_master_addrs=yb-master-0:7100,yb-master-1:7100,yb-master-2:7100 --ysql_num_shards_per_tserver=2 --rpc_connection_timeout_ms=15000
+
+      "
+    ports:
+      - "9000:9000"
+      - "5433:5433"
+    networks:
+      - lab
+    healthcheck:
+      test:
+        ["CMD", "/home/yugabyte/postgres/bin/pg_isready", "-h", "yb-tserver-0"]
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    # depends_on:
+    #   yb-master-2:
+    #     condition: service_healthy
+
+  yb-tserver-1:
+    image: yugabytedb/yugabyte:2.18.0.1-b4
+    platform: linux/amd64
+    cap_add:
+      - NET_ADMIN
+    container_name: yb-tserver-1
+    hostname: yb-tserver-1.zone.region.cloud
+    command: |
+      bash -c "
+      rm -rf /tmp/.yb* ;
+      /home/yugabyte/bin/yb-tserver --ysql_beta_feature_tablespace_alteration=true --ysql_enable_packed_row=true --ysql_beta_features=true --yb_enable_read_committed_isolation=true --default_memory_limit_to_ram_ratio=0.20 --placement_cloud=cloud --placement_region=region --placement_zone=zone --enable_ysql=true --fs_data_dirs=/home/yugabyte/data --rpc_bind_addresses=yb-tserver-1.zone.region.cloud:9100 --tserver_master_addrs=yb-master-0:7100,yb-master-1:7100,yb-master-2:7100 --ysql_num_shards_per_tserver=2 --rpc_connection_timeout_ms=15000
+
+      "
+    ports:
+      - "9001:9000"
+      - "5434:5433"
+    networks:
+      - lab
+    healthcheck:
+      test:
+        ["CMD", "/home/yugabyte/postgres/bin/pg_isready", "-h", "yb-tserver-1"]
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    # depends_on:
+    #   yb-master-2:
+    #     condition: service_healthy
+
+  yb-tserver-2:
+    image: yugabytedb/yugabyte:2.18.0.1-b4
+    platform: linux/amd64
+    cap_add:
+      - NET_ADMIN
+    container_name: yb-tserver-2
+    hostname: yb-tserver-2.zone.region.cloud
+    command: |
+      bash -c "
+      rm -rf /tmp/.yb* ;
+      /home/yugabyte/bin/yb-tserver --ysql_beta_feature_tablespace_alteration=true --ysql_enable_packed_row=true --ysql_beta_features=true --yb_enable_read_committed_isolation=true --default_memory_limit_to_ram_ratio=0.20 --placement_cloud=cloud --placement_region=region --placement_zone=zone --enable_ysql=true --fs_data_dirs=/home/yugabyte/data --rpc_bind_addresses=yb-tserver-2.zone.region.cloud:9100 --tserver_master_addrs=yb-master-0:7100,yb-master-1:7100,yb-master-2:7100 --ysql_num_shards_per_tserver=2 --rpc_connection_timeout_ms=15000
+
+      "
+    ports:
+      - "9002:9000"
+      - "5435:5433"
+    networks:
+      - lab
+    healthcheck:
+      test:
+        ["CMD", "/home/yugabyte/postgres/bin/pg_isready", "-h", "yb-tserver-2"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    # depends_on:
+    #   yb-master-2:
+    #     condition: service_healthy
+  app:
+    build: .
+    container_name: app
+    hostname: app
+    environment:
+        SPRING_DATASOURCE_HIKARI_DATA_SOURCE_PROPERTIES_SERVERNAME: yb-tserver-0
+    ports:
+      - "8080:8080"
+    networks:
+      - lab
+    depends_on:
+      yb-tserver-0:
+        condition: service_healthy


### PR DESCRIPTION
* Alternate Dockerfile:
    Added a new Dockerfile `demo.Dockerfile` which uses multistage build to remove the need to build file locally
* Docker Compose Support:
    Added `docker-compose.yaml` to run database and workload simulator in one go with a simple `docker-compose up -d` command
* Demo Docker Compose:
    Added demo file to quickly download and run the project

    ```bash
    curl -sSL https://raw.githubusercontent.com/yogendra/yb-workload-simulator/main/docker-compose.demo.yaml -o docker-compose.yaml && \
    docker-compose up 
    ```
